### PR TITLE
Revert "Update clap requirement from 3.2.6 to 4.0.18 in /sitefix"

### DIFF
--- a/sitefix/Cargo.toml
+++ b/sitefix/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "3.2.6", features = ["derive"] }
 console = "0.15.1"
 wax = "0.5.0"
 futures = "0.3"


### PR DESCRIPTION
Reverts CloudCannon/sitefix#1